### PR TITLE
Fix TextArea maxlength attribute

### DIFF
--- a/src/components/Form/TextArea.vue
+++ b/src/components/Form/TextArea.vue
@@ -1,6 +1,6 @@
 <template>
     <TextField :is-focused="isFocused">
-        <textarea v-model="text" :rows="rows" maxlength="maxlength"
+        <textarea v-model="text" :rows="rows" :maxlength="maxlength"
                   :placeholder="placeholder"
                   @focus="onFocus" @blur="onBlur" @input="onInput"/>
     </TextField>

--- a/tests/components/Form/TextArea.test.js
+++ b/tests/components/Form/TextArea.test.js
@@ -3,6 +3,20 @@ import TextArea from 'components/Form/TextArea';
 
 
 describe('TextArea', () => {
+    it('contains properly configured textarea', () => {
+        const component = shallowMount(TextArea, {
+            propsData: {
+                value: 'ABC', maxlength: 5, row: 10, placeholder: 'Placeholder'
+            }
+        });
+
+        expect(component.find('textarea').attributes()).toEqual({
+            maxlength: '5',
+            placeholder: 'Placeholder',
+            rows: '10'
+        });
+    });
+
     it('emits focus event on textarea focus', () => {
         const component = shallowMount(TextArea);
         component.find('textarea').trigger('focus');


### PR DESCRIPTION
This pull request fixes `maxlength` property setup on `TextArea.vue`. I've also added tests that covers this fix.