### PR TITLE
Fix select behaviour when the selected suggestion is no longer visible

### DIFF
--- a/src/components/Select/Select.vue
+++ b/src/components/Select/Select.vue
@@ -447,8 +447,9 @@
             },
 
             onSuggestionSelected(e) {
-                // if current index is undefined, means we don't want to select any value, just submit
-                if (this.currentSuggestionIndex === undefined && !this.canCreateTag) {
+                // if suggested option is undefined, means we don't want to select any value, just submit
+                const suggestedOption = this.suggestions && this.suggestions[this.currentSuggestionIndex];
+                if (suggestedOption === undefined && !this.canCreateTag) {
                     this.$emit('confirm', e);
                     return;
                 }
@@ -465,11 +466,10 @@
                     return;
                 }
 
-                const option = this.suggestions[this.currentSuggestionIndex];
                 this.currentSuggestionIndex = undefined;
                 this.$nextTick(() => {
                     this.$refs.input.focus();
-                    this.onOptionSelected(option);
+                    this.onOptionSelected(suggestedOption);
                 });
             },
 

--- a/tests/components/Select/Select.test.js
+++ b/tests/components/Select/Select.test.js
@@ -89,6 +89,17 @@ describe('Select', () => {
         expect(menu.exists()).toBeTruthy();
     });
 
+    test('should emit confirm on enter if the suggested option is not visible', async () => {
+        const component = mount(Select, { propsData: { value: 'foo', options } });
+        component.findComponent(TextField).trigger('click');
+        component.vm.currentSuggestionIndex = 5;
+        await component.vm.$nextTick();
+
+        component.find('input').trigger('keydown.enter');
+
+        expect(component.emitted('confirm')).toBeTruthy();
+    });
+
     it('should preselect passed array of options', () => {
         const [a, b] = options;
         const component = shallowMount(Select, { propsData: { value: [a, b], options, multi: true } });


### PR DESCRIPTION
Steps to reproduce:

1. Type a few characters in the select input so that a few suggestions appear
2. Use arrows to highlight one of the options
2. Type a few more characters so that there's no suggestion matching the string
3. Press enter - a "confirm" event should be emitted, but nothing is emitted.